### PR TITLE
Avoid loading data points when not neccesary

### DIFF
--- a/lib/algorithms/k_means/clusterer.rb
+++ b/lib/algorithms/k_means/clusterer.rb
@@ -17,7 +17,7 @@ module Algorithms
       end
 
       def run
-        load_data_points
+        load_data_points if @data_points.nil?
         compute_initial_centroids if clusters.empty?
         MAX_ITERATIONS.times do
           clear_clusters


### PR DESCRIPTION
When calling run method there is no need to load_points because we already passed them as an argument in the :data_points key.

In fact the process halts due to an exception in load_data_points, when filename is not being passed in the hash.
